### PR TITLE
added an onExit option for tasks such as copying compiled code to an …

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ function puts(error, stdout, stderr) {
 function WebpackShellPlugin(options) {
   var defaultOptions = {
     onBuildStart: [],
-    onBuildEnd: []
+    onBuildEnd: [],
+    onExit: []
   };
   if (!options.onBuildStart) {
     options.onBuildStart = defaultOptions.onBuildStart;
@@ -16,7 +17,9 @@ function WebpackShellPlugin(options) {
   if(!options.onBuildEnd) {
     options.onBuildEnd = defaultOptions.onBuildEnd;
   }
-
+  if(!options.onExit) {
+    options.onExit = defaultOptions.onExit;
+  }
   this.options = options;
 
 }
@@ -37,6 +40,13 @@ WebpackShellPlugin.prototype.apply = function(compiler) {
     options.onBuildEnd.forEach(function(script){ exec(script, puts)});
   }
   callback();
+});
+
+  compiler.plugin("done", function () {
+    if(options.onExit.length){
+    console.log("Executing addiotn scripts befor exit");
+    options.onExit.forEach(function(script){ exec(script, puts)});
+  }
 });
 };
 


### PR DESCRIPTION
…external directory.

First of all, this is a great plugin which we like a lot. This pull request aims to address a corner case described below:

When the onBuildEnd option is run, the directory which contains compiled code may still be empty. This makes plugin tasks such as copying the compiled code to an external directory or ssh it to a remote server more difficult.

When the "done" event is emitted, the compile code directory is populated. That's helpful for our user cases.