### PR TITLE
changed how the boolean options are tested for existence

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function mergeOptions(options, defaults) {
 }
 
 function WebpackShellPlugin(options) {
-  var defaultOptions = {
+  var defaults = {
     onBuildStart: [],
     onBuildEnd: [],
     onExit: [],

--- a/index.js
+++ b/index.js
@@ -41,11 +41,11 @@ function WebpackShellPlugin(options) {
     options.onExit = defaultOptions.onExit;
   }
 
-  if (!options.dev) {
+  if (!options.hasOwnProperty('dev')) {
     options.dev = defaultOptions.dev;
   }
 
-  if (!options.verbose) {
+  if (!options.hasOwnProperty('verbose')) {
     options.verbose = defaultOptions.verbose;
   }
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,16 @@ function validateInput(options) {
   return options;
 }
 
+function mergeOptions(options, defaults) {
+  for (key in defaults) {
+    if (options.hasOwnProperty(key)) {
+      defaults[key] = options[key];    
+    }
+  }
+
+  return defaults;
+}
+
 function WebpackShellPlugin(options) {
   var defaultOptions = {
     onBuildStart: [],
@@ -29,30 +39,7 @@ function WebpackShellPlugin(options) {
     verbose: false
   };
 
-  if (!options.onBuildStart) {
-    options.onBuildStart = defaultOptions.onBuildStart;
-  }
-
-  if (!options.onBuildEnd) {
-    options.onBuildEnd = defaultOptions.onBuildEnd;
-  }
-
-  if (!options.onExit) {
-    options.onExit = defaultOptions.onExit;
-  }
-
-  if (!options.hasOwnProperty('dev')) {
-    options.dev = defaultOptions.dev;
-  }
-
-  if (!options.hasOwnProperty('verbose')) {
-    options.verbose = defaultOptions.verbose;
-  }
-
-  options = validateInput(options);
-
-  this.options = options;
-
+  this.options = validateInput(mergeOptions(options, defaults));
 }
 
 WebpackShellPlugin.prototype.apply = function (compiler) {


### PR DESCRIPTION
As it was, setting the boolean options to false would ignore your setting and use the default options. This merge changes how the boolean options are tests for existence using `hasOwnProperty`.