### PR TITLE
Use child_process.spawn instead of child_process.exec to maintain colors in terminal output

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,125 @@
 'use strict';
 
-var babelHelpers = {};
+var asyncGenerator = function () {
+  function AwaitValue(value) {
+    this.value = value;
+  }
 
-babelHelpers.classCallCheck = function (instance, Constructor) {
+  function AsyncGenerator(gen) {
+    var front, back;
+
+    function send(key, arg) {
+      return new Promise(function (resolve, reject) {
+        var request = {
+          key: key,
+          arg: arg,
+          resolve: resolve,
+          reject: reject,
+          next: null
+        };
+
+        if (back) {
+          back = back.next = request;
+        } else {
+          front = back = request;
+          resume(key, arg);
+        }
+      });
+    }
+
+    function resume(key, arg) {
+      try {
+        var result = gen[key](arg);
+        var value = result.value;
+
+        if (value instanceof AwaitValue) {
+          Promise.resolve(value.value).then(function (arg) {
+            resume("next", arg);
+          }, function (arg) {
+            resume("throw", arg);
+          });
+        } else {
+          settle(result.done ? "return" : "normal", result.value);
+        }
+      } catch (err) {
+        settle("throw", err);
+      }
+    }
+
+    function settle(type, value) {
+      switch (type) {
+        case "return":
+          front.resolve({
+            value: value,
+            done: true
+          });
+          break;
+
+        case "throw":
+          front.reject(value);
+          break;
+
+        default:
+          front.resolve({
+            value: value,
+            done: false
+          });
+          break;
+      }
+
+      front = front.next;
+
+      if (front) {
+        resume(front.key, front.arg);
+      } else {
+        back = null;
+      }
+    }
+
+    this._invoke = send;
+
+    if (typeof gen.return !== "function") {
+      this.return = undefined;
+    }
+  }
+
+  if (typeof Symbol === "function" && Symbol.asyncIterator) {
+    AsyncGenerator.prototype[Symbol.asyncIterator] = function () {
+      return this;
+    };
+  }
+
+  AsyncGenerator.prototype.next = function (arg) {
+    return this._invoke("next", arg);
+  };
+
+  AsyncGenerator.prototype.throw = function (arg) {
+    return this._invoke("throw", arg);
+  };
+
+  AsyncGenerator.prototype.return = function (arg) {
+    return this._invoke("return", arg);
+  };
+
+  return {
+    wrap: function (fn) {
+      return function () {
+        return new AsyncGenerator(fn.apply(this, arguments));
+      };
+    },
+    await: function (value) {
+      return new AwaitValue(value);
+    }
+  };
+}();
+
+var classCallCheck = function (instance, Constructor) {
   if (!(instance instanceof Constructor)) {
     throw new TypeError("Cannot call a class as a function");
   }
 };
 
-babelHelpers.createClass = function () {
+var createClass = function () {
   function defineProperties(target, props) {
     for (var i = 0; i < props.length; i++) {
       var descriptor = props[i];
@@ -26,9 +137,11 @@ babelHelpers.createClass = function () {
   };
 }();
 
-babelHelpers;
+var toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
 
-var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
 var defaultOptions = {
   onBuildStart: [],
   onBuildEnd: [],
@@ -43,9 +156,29 @@ function puts(error, stdout, stderr) {
   }
 }
 
-function spreadStdoutAndStdErr(proc) {
-  proc.stdout.pipe(process.stdout);
-  proc.stderr.pipe(process.stdout);
+function serializeScript(script) {
+  if (typeof script === 'string') {
+    var _script$split = script.split(' '),
+        _script$split2 = toArray(_script$split),
+        _command = _script$split2[0],
+        _args = _script$split2.slice(1);
+
+    return { command: _command, args: _args };
+  }
+  var command = script.command,
+      args = script.args;
+
+  return { command: command, args: args };
+}
+
+function handleScript(script) {
+  var _serializeScript = serializeScript(script),
+      command = _serializeScript.command,
+      args = _serializeScript.args;
+
+  var proc = spawn(command, args, { stdio: 'inherit' });
+
+  proc.on('close', puts);
 }
 
 function validateInput(options) {
@@ -72,12 +205,12 @@ function mergeOptions(options, defaults) {
 
 var WebpackShellPlugin = function () {
   function WebpackShellPlugin(options) {
-    babelHelpers.classCallCheck(this, WebpackShellPlugin);
+    classCallCheck(this, WebpackShellPlugin);
 
     this.options = validateInput(mergeOptions(options, defaultOptions));
   }
 
-  babelHelpers.createClass(WebpackShellPlugin, [{
+  createClass(WebpackShellPlugin, [{
     key: 'apply',
     value: function apply(compiler) {
       var _this = this;
@@ -88,9 +221,7 @@ var WebpackShellPlugin = function () {
         }
         if (_this.options.onBuildStart.length) {
           console.log('Executing pre-build scripts');
-          _this.options.onBuildStart.forEach(function (script) {
-            spreadStdoutAndStdErr(exec(script, puts));
-          });
+          _this.options.onBuildStart.forEach(handleScript);
           if (_this.options.dev) {
             _this.options.onBuildStart = [];
           }
@@ -100,9 +231,7 @@ var WebpackShellPlugin = function () {
       compiler.plugin('emit', function (compilation, callback) {
         if (_this.options.onBuildEnd.length) {
           console.log('Executing post-build scripts');
-          _this.options.onBuildEnd.forEach(function (script) {
-            spreadStdoutAndStdErr(exec(script, puts));
-          });
+          _this.options.onBuildEnd.forEach(handleScript);
           if (_this.options.dev) {
             _this.options.onBuildEnd = [];
           }
@@ -113,9 +242,7 @@ var WebpackShellPlugin = function () {
       compiler.plugin('done', function () {
         if (_this.options.onBuildExit.length) {
           console.log('Executing additional scripts before exit');
-          _this.options.onBuildExit.forEach(function (script) {
-            spreadStdoutAndStdErr(exec(script, puts));
-          });
+          _this.options.onBuildExit.forEach(handleScript);
         }
       });
     }


### PR DESCRIPTION
I encountered the same issue as #17 and this seems to fix it. If you find this acceptable we'll need to update the readme to explain that there are two ways to define scripts to be run:
1. Using strings

``` javascript
plugins: [
  new WebpackShellPlugin({
    onBuildStart: [
      `command argument1 --flag argument2`
    ]
  ],
```
1. Using objects

``` javascript
plugins: [
  new WebpackShellPlugin({
    onBuildStart: [
      {
        command: 'command',
        args: [
          'argument1',
          '--flag',
          'argument2'
        ]
      }
    ]
  ],
```
