### PR TITLE
Deprecate verbose and introduce safe variable to resolve spawn issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Once the build finishes, a child process is spawned firing both a python and nod
 * `onBuildEnd`: array of scripts to execute after files are emitted at the end of the compilation. **Default: [ ]**
 * `onBuildExit`: array of scripts to execute after webpack's process is complete. **Default: [ ]**
 * `dev`: switch for development environments. This causes scripts to execute once. Useful for running HMR on webpack-dev-server or webpack watch mode. **Default: true**
-* `verbose`: enable for verbose output. **Default: false**
+* `safe`: switches script execution process from spawn to exec. If running into problems with spawn, turn this setting on. **Default: false**
+* `verbose`: **DEPRECATED** enable for verbose output. **Default: false**
 
 ### Developing
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -150,7 +150,8 @@ var defaultOptions = {
   onBuildEnd: [],
   onBuildExit: [],
   dev: true,
-  verbose: false
+  verbose: false,
+  safe: false
 };
 
 var WebpackShellPlugin = function () {
@@ -192,7 +193,7 @@ var WebpackShellPlugin = function () {
   }, {
     key: 'handleScript',
     value: function handleScript(script) {
-      if (os.platform() === 'win32') {
+      if (os.platform() === 'win32' || this.options.safe) {
         this.spreadStdoutAndStdErr(exec(script, this.puts));
       } else {
         var _serializeScript = this.serializeScript(script),
@@ -235,6 +236,7 @@ var WebpackShellPlugin = function () {
       compiler.plugin('compilation', function (compilation) {
         if (_this.options.verbose) {
           console.log('Report compilation: ' + compilation);
+          console.warn('WebpackShellPlugin [' + new Date() + ']: Verbose is being deprecated, please remove.');
         }
         if (_this.options.onBuildStart.length) {
           console.log('Executing pre-build scripts');

--- a/src/webpack-shell-plugin.js
+++ b/src/webpack-shell-plugin.js
@@ -7,9 +7,9 @@ const defaultOptions = {
   onBuildEnd: [],
   onBuildExit: [],
   dev: true,
-  verbose: false
+  verbose: false,
+  safe: false
 };
-
 
 export default class WebpackShellPlugin {
   constructor(options) {
@@ -37,7 +37,7 @@ export default class WebpackShellPlugin {
   }
 
   handleScript(script) {
-    if (os.platform() === 'win32') {
+    if (os.platform() === 'win32' || this.options.safe) {
       this.spreadStdoutAndStdErr(exec(script, this.puts));
     } else {
       const {command, args} = this.serializeScript(script);
@@ -73,6 +73,7 @@ export default class WebpackShellPlugin {
     compiler.plugin('compilation', (compilation) => {
       if (this.options.verbose) {
         console.log(`Report compilation: ${compilation}`);
+        console.warn(`WebpackShellPlugin [${new Date()}]: Verbose is being deprecated, please remove.`);
       }
       if (this.options.onBuildStart.length) {
         console.log('Executing pre-build scripts');

--- a/test.js
+++ b/test.js
@@ -1,0 +1,28 @@
+const chalk = require('chalk');
+const log = console.log;
+
+// combine styled and normal strings
+log(chalk.blue('Hello') + 'World' + chalk.red('!'));
+
+// compose multiple styles using the chainable API
+log(chalk.blue.bgRed.bold('Hello world!'));
+
+// pass in multiple arguments
+log(chalk.blue('Hello', 'World!', 'Foo', 'bar', 'biz', 'baz'));
+
+// nest styles
+log(chalk.red('Hello', chalk.underline.bgBlue('world') + '!'));
+
+// nest styles of the same type even (color, underline, background)
+log(chalk.green(
+  'I am a green line ' +
+  chalk.blue.underline.bold('with a blue substring') +
+  ' that becomes green again!'
+));
+
+// ES2015 template literal
+log(`
+CPU: ${chalk.red('90%')}
+RAM: ${chalk.green('40%')}
+DISK: ${chalk.yellow('70%')}
+`);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 
-var WebpackShellPlugin = require('./lib');
+const WebpackShellPlugin = require('./lib');
 
 module.exports = {
   watch: true,
@@ -19,7 +19,7 @@ module.exports = {
     ]
   },
   plugins: [
-    new WebpackShellPlugin({onBuildStart:['echo "Webpack Start"'], onBuildEnd:['echo "Webpack End"']}),
+    new WebpackShellPlugin({onBuildStart:['node test.js'], onBuildEnd:['echo "Webpack End"'], safe: true, verbose: true}),
     new webpack.HotModuleReplacementPlugin()
   ]
 };


### PR DESCRIPTION
To support #27, issue with spawn working with certain script operators, we need to have a method to support multiple streams, as we only serialize to 1 stream right now.

For a fix I, introduced a new field `safe` which will run exec instead of spawn, as we don't have to manage streams with exec (since it's just a buffer output).