### PR TITLE
feat: option swallowError

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Once the build finishes, a child process is spawned firing both a python and nod
 * `dev`: switch for development environments. This causes scripts to execute once. Useful for running HMR on webpack-dev-server or webpack watch mode. **Default: true**
 * `safe`: switches script execution process from spawn to exec. If running into problems with spawn, turn this setting on. **Default: false**
 * `verbose`: **DEPRECATED** enable for verbose output. **Default: false**
+* `swallowError`: ignore script errors (useful in watch mode) **Default: false**
 
 ### Developing
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,118 +1,5 @@
 'use strict';
 
-var asyncGenerator = function () {
-  function AwaitValue(value) {
-    this.value = value;
-  }
-
-  function AsyncGenerator(gen) {
-    var front, back;
-
-    function send(key, arg) {
-      return new Promise(function (resolve, reject) {
-        var request = {
-          key: key,
-          arg: arg,
-          resolve: resolve,
-          reject: reject,
-          next: null
-        };
-
-        if (back) {
-          back = back.next = request;
-        } else {
-          front = back = request;
-          resume(key, arg);
-        }
-      });
-    }
-
-    function resume(key, arg) {
-      try {
-        var result = gen[key](arg);
-        var value = result.value;
-
-        if (value instanceof AwaitValue) {
-          Promise.resolve(value.value).then(function (arg) {
-            resume("next", arg);
-          }, function (arg) {
-            resume("throw", arg);
-          });
-        } else {
-          settle(result.done ? "return" : "normal", result.value);
-        }
-      } catch (err) {
-        settle("throw", err);
-      }
-    }
-
-    function settle(type, value) {
-      switch (type) {
-        case "return":
-          front.resolve({
-            value: value,
-            done: true
-          });
-          break;
-
-        case "throw":
-          front.reject(value);
-          break;
-
-        default:
-          front.resolve({
-            value: value,
-            done: false
-          });
-          break;
-      }
-
-      front = front.next;
-
-      if (front) {
-        resume(front.key, front.arg);
-      } else {
-        back = null;
-      }
-    }
-
-    this._invoke = send;
-
-    if (typeof gen.return !== "function") {
-      this.return = undefined;
-    }
-  }
-
-  if (typeof Symbol === "function" && Symbol.asyncIterator) {
-    AsyncGenerator.prototype[Symbol.asyncIterator] = function () {
-      return this;
-    };
-  }
-
-  AsyncGenerator.prototype.next = function (arg) {
-    return this._invoke("next", arg);
-  };
-
-  AsyncGenerator.prototype.throw = function (arg) {
-    return this._invoke("throw", arg);
-  };
-
-  AsyncGenerator.prototype.return = function (arg) {
-    return this._invoke("return", arg);
-  };
-
-  return {
-    wrap: function (fn) {
-      return function () {
-        return new AsyncGenerator(fn.apply(this, arguments));
-      };
-    },
-    await: function (value) {
-      return new AwaitValue(value);
-    }
-  };
-}();
-
 var classCallCheck = function (instance, Constructor) {
   if (!(instance instanceof Constructor)) {
     throw new TypeError("Cannot call a class as a function");
@@ -137,6 +24,44 @@ var createClass = function () {
   };
 }();
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 var toArray = function (arr) {
   return Array.isArray(arr) ? arr : Array.from(arr);
 };
@@ -151,7 +76,8 @@ var defaultOptions = {
   onBuildExit: [],
   dev: true,
   verbose: false,
-  safe: false
+  safe: false,
+  swallowError: false
 };
 
 var WebpackShellPlugin = function () {
@@ -164,7 +90,7 @@ var WebpackShellPlugin = function () {
   createClass(WebpackShellPlugin, [{
     key: 'puts',
     value: function puts(error, stdout, stderr) {
-      if (error) {
+      if (error && !this.options.swallowError) {
         throw error;
       }
     }
@@ -220,13 +146,13 @@ var WebpackShellPlugin = function () {
     }
   }, {
     key: 'mergeOptions',
-    value: function mergeOptions(options, defaults) {
-      for (var key in defaults) {
+    value: function mergeOptions(options, defaults$$1) {
+      for (var key in defaults$$1) {
         if (options.hasOwnProperty(key)) {
-          defaults[key] = options[key];
+          defaults$$1[key] = options[key];
         }
       }
-      return defaults;
+      return defaults$$1;
     }
   }, {
     key: 'apply',

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ var WebpackShellPlugin = function () {
 
   createClass(WebpackShellPlugin, [{
     key: 'puts',
-    value: function puts(error, stdout, stderr) {
+    value: function puts(error) {
       if (error && !this.options.swallowError) {
         throw error;
       }
@@ -120,14 +120,14 @@ var WebpackShellPlugin = function () {
     key: 'handleScript',
     value: function handleScript(script) {
       if (os.platform() === 'win32' || this.options.safe) {
-        this.spreadStdoutAndStdErr(exec(script, this.puts));
+        this.spreadStdoutAndStdErr(exec(script, this.puts.bind(this)));
       } else {
         var _serializeScript = this.serializeScript(script),
             command = _serializeScript.command,
             args = _serializeScript.args;
 
         var proc = spawn(command, args, { stdio: 'inherit' });
-        proc.on('close', this.puts);
+        proc.on('close', this.puts.bind(this));
       }
     }
   }, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-shell-plugin",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Run shell commands before and after webpack builds",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   "homepage": "https://github.com/1337programming/webpack-shell-plugin",
   "devDependencies": {
     "babel-core": "^6.7.6",
-    "babel-preset-es2015-rollup": "^1.1.1",
-    "css-loader": "^0.23.1",
-    "eslint": "^2.7.0",
-    "rollup": "^0.25.8",
+    "babel-preset-es2015-rollup": "^3.0.0",
+    "css-loader": "^0.28.0",
+    "eslint": "^3.19.0",
+    "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.4.0",
-    "style-loader": "^0.13.1",
-    "webpack": "^1.13.1"
+    "style-loader": "^0.16.1",
+    "webpack": "^2.4.1"
   }
 }

--- a/src/webpack-shell-plugin.js
+++ b/src/webpack-shell-plugin.js
@@ -17,7 +17,7 @@ export default class WebpackShellPlugin {
     this.options = this.validateInput(this.mergeOptions(options, defaultOptions));
   }
 
-  puts(error, stdout, stderr) {
+  puts(error) {
     if (error && !this.options.swallowError) {
       throw error;
     }
@@ -39,11 +39,11 @@ export default class WebpackShellPlugin {
 
   handleScript(script) {
     if (os.platform() === 'win32' || this.options.safe) {
-      this.spreadStdoutAndStdErr(exec(script, this.puts));
+      this.spreadStdoutAndStdErr(exec(script, this.puts.bind(this)));
     } else {
       const {command, args} = this.serializeScript(script);
       const proc = spawn(command, args, {stdio: 'inherit'});
-      proc.on('close', this.puts);
+      proc.on('close', this.puts.bind(this));
     }
   }
 

--- a/src/webpack-shell-plugin.js
+++ b/src/webpack-shell-plugin.js
@@ -8,7 +8,8 @@ const defaultOptions = {
   onBuildExit: [],
   dev: true,
   verbose: false,
-  safe: false
+  safe: false,
+  swallowError: false
 };
 
 export default class WebpackShellPlugin {
@@ -17,7 +18,7 @@ export default class WebpackShellPlugin {
   }
 
   puts(error, stdout, stderr) {
-    if (error) {
+    if (error && !swallowError) {
       throw error;
     }
   }

--- a/src/webpack-shell-plugin.js
+++ b/src/webpack-shell-plugin.js
@@ -18,7 +18,7 @@ export default class WebpackShellPlugin {
   }
 
   puts(error, stdout, stderr) {
-    if (error && !swallowError) {
+    if (error && !this.options.swallowError) {
       throw error;
     }
   }


### PR DESCRIPTION
I use webpack-shell-plugin to run my unit tests after bundling them with webpack (using mocha). 
In watch mode any failed tests would take down webpack because the shell plugin is throwing an error.
So I added the possibility to swallow any errors of the shell scripts.

The build process failed with the current dependencies so I needed to update them to their latest versions.