### PR TITLE
Add onBeforeBuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ module.exports = config;
 Once the build finishes, a child process is spawned firing both a python and node script.
 
 ### API
+* `onBeforeBuild`: array of scripts to execute before every build. **Default: [ ]**
 * `onBuildStart`: array of scripts to execute on the initial build. **Default: [ ]**
 * `onBuildEnd`: array of scripts to execute after files are emitted at the end of the compilation. **Default: [ ]**
 * `onBuildExit`: array of scripts to execute after webpack's process is complete. *Note: this event also fires in `webpack --watch` when webpack has finished updating the bundle.* **Default: [ ]**

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,6 +146,7 @@ var exec = require('child_process').exec;
 var os = require('os');
 
 var defaultOptions = {
+  onBeforeBuild: [],
   onBuildStart: [],
   onBuildEnd: [],
   onBuildExit: [],
@@ -207,6 +208,9 @@ var WebpackShellPlugin = function () {
   }, {
     key: 'validateInput',
     value: function validateInput(options) {
+      if (typeof options.onBeforeBuild === 'string') {
+        options.onBeforeBuild = options.onBeforeBuild.split('&&');
+      }
       if (typeof options.onBuildStart === 'string') {
         options.onBuildStart = options.onBuildStart.split('&&');
       }
@@ -232,6 +236,15 @@ var WebpackShellPlugin = function () {
     key: 'apply',
     value: function apply(compiler) {
       var _this = this;
+
+      compiler.plugin('invalid', function () {
+        if (this.options.onBeforeBuild.length) {
+          console.log('Executing before build scripts');
+          for (var i = 0; i < this.options.onBeforeBuild.length; i++) {
+            this.handleScript(this.options.onBeforeBuild[i]);
+          }
+        }
+      });
 
       compiler.plugin('compilation', function (compilation) {
         if (_this.options.verbose) {

--- a/src/webpack-shell-plugin.js
+++ b/src/webpack-shell-plugin.js
@@ -3,6 +3,7 @@ const exec = require('child_process').exec;
 const os = require('os');
 
 const defaultOptions = {
+  onBeforeBuild: [],
   onBuildStart: [],
   onBuildEnd: [],
   onBuildExit: [],
@@ -47,6 +48,9 @@ export default class WebpackShellPlugin {
   }
 
   validateInput(options) {
+    if (typeof options.onBeforeBuild === 'string') {
+      options.onBeforeBuild = options.onBeforeBuild.split('&&');
+    }
     if (typeof options.onBuildStart === 'string') {
       options.onBuildStart = options.onBuildStart.split('&&');
     }
@@ -69,6 +73,14 @@ export default class WebpackShellPlugin {
   }
 
   apply(compiler) {
+    compiler.plugin('invalid', function () {
+      if (this.options.onBeforeBuild.length) {
+        console.log('Executing before build scripts');
+        for (var i = 0; i < this.options.onBeforeBuild.length; i++) {
+          this.handleScript(this.options.onBeforeBuild[i]);
+        }
+      }
+    });
 
     compiler.plugin('compilation', (compilation) => {
       if (this.options.verbose) {


### PR DESCRIPTION
Implementing webpack's `invalid`. 

I needed this because I'm running an external script, to compile some files using PHP, and generating a `.js` file which should be then processed by webpack. Using `onBuildStart` did not fired it the way I thought it would, before webpack start to build things, and `onBuildExit`, saves the file after everything is done, firing a new webpack watch event, which results in a loop. The real problem was that, even when I had it updated at some point (yes it kind of worked without this), it was too late for LiveReload to catch the update files.

This is the use case:

```
const LiveReloadPlugin = require('webpack-livereload-plugin');
const WebpackShellPlugin = require('webpack-shell-plugin');
const CopyWebpackPlugin = require('copy-webpack-plugin');

mix.webpackConfig({
    plugins: [
        new LiveReloadPlugin(),

        new CopyWebpackPlugin([
            { from: 'resources/lang', to: '/tmp/resources/lang' },
        ], {
            copyUnmodified: true
        }),

        new WebpackShellPlugin({
            onBeforeBuild:['php artisan app:build-localization-json'],
        }),
    ]
});
```

`CopyWebpackPlugin` is responsible for watching those external files and triggering the change event during watch.

