### PR TITLE
Create an options object for each plugin instance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -220,13 +220,16 @@ var WebpackShellPlugin = function () {
     }
   }, {
     key: 'mergeOptions',
-    value: function mergeOptions(options, defaults) {
+    value: function mergeOptions(provided, defaults) {
+      var options = {};
       for (var key in defaults) {
-        if (options.hasOwnProperty(key)) {
-          defaults[key] = options[key];
+        if (provided.hasOwnProperty(key)) {
+          options[key] = provided[key];
+        } else {
+          options[key] = defaults[key];
         }
       }
-      return defaults;
+      return options;
     }
   }, {
     key: 'apply',

--- a/src/webpack-shell-plugin.js
+++ b/src/webpack-shell-plugin.js
@@ -59,13 +59,16 @@ export default class WebpackShellPlugin {
     return options;
   }
 
-  mergeOptions(options, defaults) {
-    for (const key in defaults) {
-      if (options.hasOwnProperty(key)) {
-        defaults[key] = options[key];
+  mergeOptions(provided, defaults) {
+    const options = {};
+    for (var key in defaults) {
+      if (provided.hasOwnProperty(key)) {
+        options[key] = provided[key];
+      } else {
+        options[key] = defaults[key];
       }
     }
-    return defaults;
+    return options;
   }
 
   apply(compiler) {


### PR DESCRIPTION
When using `webpack-shell-plugin`, the same `options` object appears to be reused for different instances. As a result, only one instance is usable at a time. This is problematic when [using multiple configurations](https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations), if they run different commands.

This patch creates a new object for each instance in `mergeOptions`, rather than changing `defaults`

Fixes #56 
